### PR TITLE
ci(release): run release-please on main pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,16 @@ name: release
 
 on:
   workflow_dispatch:
-  release:
-    types: [released]
+  push:
+    branches: [main]
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  release:
-    uses: parkerbxyz/.github/.github/workflows/release.yml@main
+  release-please:
+    uses: parkerbxyz/.github/.github/workflows/release-please.yml@main
     secrets: inherit
+    with:
+      release-type: 'node'


### PR DESCRIPTION
Release automation in this repo was only responding after a GitHub release already existed, so release-please did not run on normal pushes to `main`.

This switches the workflow to the same reusable release-please workflow used by `suggest-changes`, triggered on pushes to `main` with pull request write permissions and the Node release type.